### PR TITLE
Update pom.apt.vm

### DIFF
--- a/content/apt/pom.apt.vm
+++ b/content/apt/pom.apt.vm
@@ -2033,4 +2033,4 @@ mvn help:active-profiles
 ======================
 
   Aspects of this guide were originally published in the
-  {{{http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html}Maven 2 Pom Demystified}}.
+  {{{https://web.archive.org/web/20100327140148/https://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html}Maven 2 Pom Demystified}}.


### PR DESCRIPTION
Replaced link to "Maven 2 Pom Demystified".

The current link no longer works. I replaced it with the latest working Internet Archive link.